### PR TITLE
Fix/kommune info client til interface

### DIFF
--- a/sosialhjelp-common-kommuneinfo-client/src/main/kotlin/no/nav/sosialhjelp/client/kommuneinfo/KommuneInfoClient.kt
+++ b/sosialhjelp-common-kommuneinfo-client/src/main/kotlin/no/nav/sosialhjelp/client/kommuneinfo/KommuneInfoClient.kt
@@ -8,10 +8,10 @@ import org.springframework.http.HttpMethod
 import org.springframework.web.client.RestTemplate
 
 
-class KommuneInfoClient(
-        private val restTemplate: RestTemplate,
-        private val fiksProperties: FiksProperties
-) {
+interface KommuneInfoClient {
+
+    val restTemplate: RestTemplate
+    val fiksProperties: FiksProperties
 
     fun hentKommuneInfo(kommunenummer: String, headers: HttpHeaders): KommuneInfo {
         val vars = mapOf("kommunenummer" to kommunenummer)

--- a/sosialhjelp-common-kommuneinfo-client/src/main/kotlin/no/nav/sosialhjelp/client/kommuneinfo/KommuneInfoClient.kt
+++ b/sosialhjelp-common-kommuneinfo-client/src/main/kotlin/no/nav/sosialhjelp/client/kommuneinfo/KommuneInfoClient.kt
@@ -13,6 +13,10 @@ interface KommuneInfoClient {
     val restTemplate: RestTemplate
     val fiksProperties: FiksProperties
 
+    fun get(kommunenummer: String): KommuneInfo
+
+    fun getAll(): List<KommuneInfo>
+
     fun hentKommuneInfo(kommunenummer: String, headers: HttpHeaders): KommuneInfo {
         val vars = mapOf("kommunenummer" to kommunenummer)
 

--- a/sosialhjelp-common-kommuneinfo-client/src/test/kotlin/no/nav/sosialhjelp/client/kommuneinfo/KommuneInfoClientTest.kt
+++ b/sosialhjelp-common-kommuneinfo-client/src/test/kotlin/no/nav/sosialhjelp/client/kommuneinfo/KommuneInfoClientTest.kt
@@ -20,7 +20,12 @@ internal class KommuneInfoClientTest {
     private val restTemplate: RestTemplate = mockk()
     private val fiksProperties = FiksProperties("a", "b")
 
-    private val client = KommuneInfoClient(restTemplate, fiksProperties)
+    private class Client(
+            override val restTemplate: RestTemplate,
+            override val fiksProperties: FiksProperties
+    ) : KommuneInfoClient
+
+    private val client = Client(restTemplate, fiksProperties)
 
     private val mockKommuneInfo: KommuneInfo = mockk()
 

--- a/sosialhjelp-common-kommuneinfo-client/src/test/kotlin/no/nav/sosialhjelp/client/kommuneinfo/KommuneInfoClientTest.kt
+++ b/sosialhjelp-common-kommuneinfo-client/src/test/kotlin/no/nav/sosialhjelp/client/kommuneinfo/KommuneInfoClientTest.kt
@@ -23,7 +23,14 @@ internal class KommuneInfoClientTest {
     private class Client(
             override val restTemplate: RestTemplate,
             override val fiksProperties: FiksProperties
-    ) : KommuneInfoClient
+    ) : KommuneInfoClient {
+        override fun get(kommunenummer: String): KommuneInfo {
+            TODO("Not yet implemented")
+        }
+        override fun getAll(): List<KommuneInfo> {
+            TODO("Not yet implemented")
+        }
+    }
 
     private val client = Client(restTemplate, fiksProperties)
 


### PR DESCRIPTION
Endrer til interface som kan implementeres av eks "KommuneInfoClientImpl" eller "KommuneInfoClientMock".

Implementerende klasser må override get(kommunenummer) og getAll(), og kan bruke hentKommuneInfo(kommunenummer) og hentAlleKommuneInfo() til hjelp. Eks:

```
    override fun get(kommunenummer: String): KommuneInfo {
            val headers = IntegrationUtils.fiksHeaders(clientProperties, getToken())
            return hentKommuneInfo(kommunenummer, headers)
    }
```