### PR TITLE
Teste å hente reponavn uten å bruke event

### DIFF
--- a/.github/workflows/snyk-job.yml
+++ b/.github/workflows/snyk-job.yml
@@ -11,13 +11,16 @@ jobs:
   snyk:
     runs-on: ubuntu-latest
     steps:
+      - name: Get repository-name
+        run: echo "REPOSITORY_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
+        shell: bash
       - uses: actions/checkout@v2
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/gradle-jdk11@master
+        with:
+          command: monitor
+          args: --org=teamdigisos --project-name=${{ env.REPOSITORY_NAME }} --remote-repo-url=${{ env.REPOSITORY_NAME }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           ORG_GRADLE_PROJECT_githubUser: x-access-token
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: --all-sub-projects --org=teamdigisos --project-name=${{ github.event.repository.name }} --remote-repo-url=${{ github.event.repository.name }}
-          command: monitor


### PR DESCRIPTION
Dette fordi daily snyk bruker on.schedule som ikke har noe event-body.

Testet OK at når snyk monitor har samme reponavn som PR så vil PR ikke lenger bry seg om ignorerte sårbarheter.