### PR TITLE
Fjerner project-name pga inkompatibilitet

### DIFF
--- a/.github/workflows/snyk-job.yml
+++ b/.github/workflows/snyk-job.yml
@@ -19,7 +19,7 @@ jobs:
         uses: snyk/actions/gradle-jdk11@master
         with:
           command: monitor
-          args: --all-sub-projects --org=teamdigisos --project-name=${{ env.REPOSITORY_NAME }} --remote-repo-url=${{ env.REPOSITORY_NAME }}
+          args: --all-sub-projects --org=teamdigisos --remote-repo-url=${{ env.REPOSITORY_NAME }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           ORG_GRADLE_PROJECT_githubUser: x-access-token


### PR DESCRIPTION
`--all-sub-projects` is currently not compatible with `--project-name`

Se actions: https://github.com/navikt/sosialhjelp-common/runs/2463905472?check_suite_focus=true