### PR TITLE
Fjerner project-name fra PR også

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/gradle-jdk11@master
         with:
-          args: --all-sub-projects --org=teamdigisos --project-name=${{ github.event.repository.name }} --remote-repo-url=${{ github.event.repository.name }}
+          args: --all-sub-projects --org=teamdigisos --remote-repo-url=${{ github.event.repository.name }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           ORG_GRADLE_PROJECT_githubUser: x-access-token


### PR DESCRIPTION
Så den blir lik som snykjob, som ikke kan ha projectname pga: 
`--all-sub-projects` is currently not compatible with `--project-name`