### PR TITLE
fjerner truststoreType og truststoreFilepath som properties

### DIFF
--- a/sosialhjelp-common-idporten-client/src/main/kotlin/no/nav/sosialhjelp/idporten/client/IdPortenClient.kt
+++ b/sosialhjelp-common-idporten-client/src/main/kotlin/no/nav/sosialhjelp/idporten/client/IdPortenClient.kt
@@ -85,10 +85,10 @@ class IdPortenClient(
             File("${idPortenProperties.virksomhetSertifikatPath}/credentials.json").readText(Charsets.UTF_8)
         )
 
-        val pair = KeyStore.getInstance(idPortenProperties.truststoreType).let { keyStore ->
+        val pair = KeyStore.getInstance(virksertCredentials.type).let { keyStore ->
             keyStore.load(
                 java.util.Base64.getDecoder().decode(
-                    File("${idPortenProperties.virksomhetSertifikatPath}/${idPortenProperties.truststoreFilepath}").readText(
+                    File("${idPortenProperties.virksomhetSertifikatPath}/${idPortenProperties.truststoreFilename}").readText(
                         Charsets.UTF_8
                     )
                 ).inputStream(),

--- a/sosialhjelp-common-idporten-client/src/main/kotlin/no/nav/sosialhjelp/idporten/client/IdPortenClient.kt
+++ b/sosialhjelp-common-idporten-client/src/main/kotlin/no/nav/sosialhjelp/idporten/client/IdPortenClient.kt
@@ -81,16 +81,15 @@ class IdPortenClient(
             it.add(Calendar.SECOND, expirySeconds)
             it.time
         }
+
         val virksertCredentials = objectMapper.readValue<VirksertCredentials>(
-            File("${idPortenProperties.virksomhetSertifikatPath}/credentials.json").readText(Charsets.UTF_8)
+            File("${idPortenProperties.virksomhetSertifikatPath}/$credentialsJson").readText(Charsets.UTF_8)
         )
 
         val pair = KeyStore.getInstance(virksertCredentials.type).let { keyStore ->
             keyStore.load(
                 java.util.Base64.getDecoder().decode(
-                    File("${idPortenProperties.virksomhetSertifikatPath}/${idPortenProperties.truststoreFilename}").readText(
-                        Charsets.UTF_8
-                    )
+                    File("${idPortenProperties.virksomhetSertifikatPath}/$truststoreFile").readText(Charsets.UTF_8)
                 ).inputStream(),
                 virksertCredentials.password.toCharArray()
             )
@@ -126,6 +125,9 @@ class IdPortenClient(
     }
 
     companion object {
+
+        private const val credentialsJson = "credentials.json"
+        private const val truststoreFile = "key.p12.b64"
 
         private const val MAX_EXPIRY_SECONDS = 120
         private const val CLAIMS_SCOPE = "scope"

--- a/sosialhjelp-common-idporten-client/src/main/kotlin/no/nav/sosialhjelp/idporten/client/IdPortenProperties.kt
+++ b/sosialhjelp-common-idporten-client/src/main/kotlin/no/nav/sosialhjelp/idporten/client/IdPortenProperties.kt
@@ -5,6 +5,5 @@ data class IdPortenProperties(
     val clientId: String,
     val scope: String,
     val configUrl: String,
-    val truststoreFilename: String,
     val virksomhetSertifikatPath: String
 )

--- a/sosialhjelp-common-idporten-client/src/main/kotlin/no/nav/sosialhjelp/idporten/client/IdPortenProperties.kt
+++ b/sosialhjelp-common-idporten-client/src/main/kotlin/no/nav/sosialhjelp/idporten/client/IdPortenProperties.kt
@@ -5,7 +5,6 @@ data class IdPortenProperties(
     val clientId: String,
     val scope: String,
     val configUrl: String,
-    val truststoreType: String,
-    val truststoreFilepath: String,
+    val truststoreFilename: String,
     val virksomhetSertifikatPath: String
 )


### PR DESCRIPTION
truststoreType kan hentes fra virksertCredentials.type.

Trekker ut credentials og truststorefilename til konstanter